### PR TITLE
Fix issue when n=1

### DIFF
--- a/R/HiClimR.R
+++ b/R/HiClimR.R
@@ -324,7 +324,7 @@ HiClimR <- function(x = list(),
     }
     
     m <- mm[nvar]
-    x <- xx[, (mm0 + 1):(mm0 + m)]
+    x <- xx[, (mm0 + 1):(mm0 + m), drop=FALSE]
     
     if (verbose)
       write("---> Computing mean for each row...", "")
@@ -393,7 +393,7 @@ HiClimR <- function(x = list(),
     
     m <- mm[nvar]
     v <- vv[[nvar]]
-    x <- xx[, (mm0 + 1):(mm0 + m)]
+    x <- xx[, (mm0 + 1):(mm0 + m), drop=FALSE]
     
     if (verbose)
       write("---> Applying mask...", "")


### PR DESCRIPTION
Currently, when x has a matrix with a single column, `HiClimR` will fail (owing do the big R trap of dropping dimensions of a Matrix with M[,1]) with error message _'x' must be an array of at least two dimensions_. 

The pull request solves this issue, and now the same code will lead to the intended _must have n ≥ 2 objects to cluster_ error message, which is hopefully more instructive (although calling this _object_ seems a little confusing?). 

``` r
library(HiClimR)

x <- TestCase$x
lon <- TestCase$lon
lat <- TestCase$lat

y <- HiClimR(x[,c(1),drop=FALSE], lon = lon, lat = lat, plot=FALSE, verbose=FALSE)
#> Error in rowMeans(x): 'x' must be an array of at least two dimensions
```

